### PR TITLE
Set query in params object to filter resource list correctly

### DIFF
--- a/src/js/actions.js
+++ b/src/js/actions.js
@@ -196,6 +196,8 @@ export function indexLoad(category, index, selection) {
     let query = index.query;
     if (loc.query.q) {
       query = Query.create(loc.query.q);
+    }
+    if (query) {
       params = { ...params, ...{ query: query } };
     }
     if (selection) {


### PR DESCRIPTION
This pull request should resolve the issue I've created within the grommet-index repo (grommet/grommet-index#3).

### Issue – Resource list not displaying correct items
While a status filter is applied, when you leave the current resource, and go back to it, the whole resource list gets loaded and doesn't get filtered. 

Steps to reproduce: 
1. Go to server-hardware view.
2. Apply status filter critical. You should see the number 150, change to 5.
3. Go to enclosures view.
4. Go back to server-hardware view.
5. You should see the filter is still applied (Critical) and the whole resource list unfiltered (150 items).

I noticed when you load more items, the filter gets applied (see attached gif at 0:24 sec).

![resource list not displaying correct items](https://cloud.githubusercontent.com/assets/3210082/11759725/00671e54-a026-11e5-856a-0bbb29378279.gif)


### Fix – Set query in params object
Set query variable to query from index store.
If url has query, update query variable.
If query is defined, set in params object.

