### PR TITLE
Redux devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "gulp-rsync": "0.0.5",
     "mkdirp": "^0.5.1",
     "react-hot-loader": "^1.3.0",
-    "redux-devtools": "^2.1.5",
+    "redux-devtools": "^3.0.1",
+    "redux-devtools-dock-monitor": "^1.0.1",
+    "redux-devtools-log-monitor": "^1.0.1",
     "yargs": "^3.30.0"
   },
   "scripts": {

--- a/src/js/DevTools.js
+++ b/src/js/DevTools.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createDevTools } from 'redux-devtools';
+import LogMonitor from 'redux-devtools-log-monitor';
+import DockMonitor from 'redux-devtools-dock-monitor';
+
+const DevTools = createDevTools(
+  <DockMonitor
+    toggleVisibilityKey='ctrl-h'
+    changePositionKey='ctrl-q'
+    defaultIsVisible={false}
+  >
+    <LogMonitor theme='monokai' />
+  </DockMonitor>
+);
+
+export default DevTools;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,7 +11,7 @@ import { getCurrentLocale, getLocaleData } from 'grommet/utils/Locale';
 import { addLocaleData } from 'react-intl';
 import en from 'react-intl/lib/locale-data/en';
 import Routes from './Routes';
-import DevTools from './DevTools';
+// import DevTools from './DevTools';
 import { Provider } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 
@@ -71,7 +71,9 @@ ReactDOM.render((
         <Router routes={Routes.routes} history={createStoreHistory()} />
       </IntlProvider>
     </Provider>
+    {/*}
     <DevTools store={store} />
+    {*/}
   </div>
 ), element);
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,7 +11,7 @@ import { getCurrentLocale, getLocaleData } from 'grommet/utils/Locale';
 import { addLocaleData } from 'react-intl';
 import en from 'react-intl/lib/locale-data/en';
 import Routes from './Routes';
-////import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
+import DevTools from './DevTools';
 import { Provider } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 
@@ -71,11 +71,7 @@ ReactDOM.render((
         <Router routes={Routes.routes} history={createStoreHistory()} />
       </IntlProvider>
     </Provider>
-    {/*}
-    <DebugPanel top right bottom>
-      <DevTools store={store} monitor={LogMonitor} />
-    </DebugPanel>
-    {*/}
+    <DevTools store={store} />
   </div>
 ), element);
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -2,7 +2,7 @@
 
 import { createStore, combineReducers, compose, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import { devTools } from 'redux-devtools';
+import DevTools from './DevTools';
 
 // TODO: fix webpack loader to allow import * from './reducers'
 import session from './reducers/session';
@@ -14,5 +14,5 @@ import item from './reducers/item';
 
 export default compose(
   applyMiddleware(thunk),
-  devTools()
+  DevTools.instrument()
 )(createStore)(combineReducers({session, route, nav, dashboard, index, item}));

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -2,7 +2,7 @@
 
 import { createStore, combineReducers, compose, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import DevTools from './DevTools';
+// import DevTools from './DevTools';
 
 // TODO: fix webpack loader to allow import * from './reducers'
 import session from './reducers/session';
@@ -14,5 +14,5 @@ import item from './reducers/item';
 
 export default compose(
   applyMiddleware(thunk),
-  DevTools.instrument()
+  // DevTools.instrument()
 )(createStore)(combineReducers({session, route, nav, dashboard, index, item}));


### PR DESCRIPTION
Updated Redux DevTools to 3.x. 

To use DevTools, uncomment `DevTools` component within index.js & store.js (see c196d43).
- `ctrl-h` toggle visibility.
- `ctrl-q` change position.


Probably would be better to handle this with env variables, e.g. `(process.env.NODE_ENV !== 'production)`