### PR TITLE
added dev package for gulp dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "ws": "^0.7.2"
   },
   "devDependencies": {
+    "babel-plugin-transform-object-rest-spread": "^6.3.13",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
     "del": "^2.0.2",
     "gulp": "^3.9.0",
     "gulp-git": "^1.2.3",


### PR DESCRIPTION
after cloning the repo and npm install, gulp dev fails due to missing dependencies such as babel-preset-es2015. I've added 3 dependencies to devDependencies in package.json.