### PR TITLE
Fix dashboard search spacing

### DIFF
--- a/src/js/components/Dashboard.js
+++ b/src/js/components/Dashboard.js
@@ -5,7 +5,6 @@ import ReactDOM from 'react-dom';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { navActivate, dashboardLayout, dashboardLoad, dashboardSearch, dashboardUnload, indexNav, indexSelect } from '../actions';
-import Box from 'grommet/components/Box';
 import Tiles from 'grommet/components/Tiles';
 import Tile from 'grommet/components/Tile';
 import Header from 'grommet/components/Header';
@@ -203,14 +202,13 @@ class Dashboard extends Component {
 
     return (
       <div ref="content" className="dashboard">
-        <Header direction="row" justify="between" large={true} pad={{horizontal: 'medium'}}>
+        <Header direction="row" justify="between" large={true}
+          pad={{horizontal: 'medium', between: 'small'}}>
           {title}
-          <Box direction="row" pad={!navActive ? {horizontal: 'medium'} : 'none'} className="flex">
-            <Search ref="search" inline={true}
-              placeHolder="Search" fill={true}
-              defaultValue={searchText} onChange={this._onSearch}
-              suggestions={searchSuggestions} />
-          </Box>
+          <Search ref="search" inline={true}
+            placeHolder="Search" fill={true}
+            defaultValue={searchText} onChange={this._onSearch}
+            suggestions={searchSuggestions} />
           {session}
         </Header>
         <Tiles ref="tiles" fill={true} flush={false}>

--- a/src/js/components/Dashboard.js
+++ b/src/js/components/Dashboard.js
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { navActivate, dashboardLayout, dashboardLoad, dashboardSearch, dashboardUnload, indexNav, indexSelect } from '../actions';
-// import Box from 'grommet/components/Box';
+import Box from 'grommet/components/Box';
 import Tiles from 'grommet/components/Tiles';
 import Tile from 'grommet/components/Tile';
 import Header from 'grommet/components/Header';
@@ -205,10 +205,12 @@ class Dashboard extends Component {
       <div ref="content" className="dashboard">
         <Header direction="row" justify="between" large={true} pad={{horizontal: 'medium'}}>
           {title}
-          <Search ref="search" inline={true} className="flex"
-            placeHolder="Search"
-            defaultValue={searchText} onChange={this._onSearch}
-            suggestions={searchSuggestions} />
+          <Box direction="row" pad={!navActive ? {horizontal: 'medium'} : 'none'} className="flex">
+            <Search ref="search" inline={true}
+              placeHolder="Search" fill={true}
+              defaultValue={searchText} onChange={this._onSearch}
+              suggestions={searchSuggestions} />
+          </Box>
           {session}
         </Header>
         <Tiles ref="tiles" fill={true} flush={false}>


### PR DESCRIPTION
Search is currently flushed next to the logo & user profile icon. 

![screen shot 2016-03-03 at 8 56 05 pm](https://cloud.githubusercontent.com/assets/3210082/13527135/02191dca-e1b1-11e5-8637-7a9c4f029d73.png)
