### PR TITLE
Fix title getting truncated

### DIFF
--- a/src/js/components/Dashboard.js
+++ b/src/js/components/Dashboard.js
@@ -204,7 +204,9 @@ class Dashboard extends Component {
       <div ref="content" className="dashboard">
         <Header direction="row" justify="between" large={true}
           pad={{horizontal: 'medium', between: 'small'}}>
-          {title}
+          <div> {/* Wrap title in div to prevent it from getting truncated */}
+            {title}
+          </div>
           <Search ref="search" inline={true}
             placeHolder="Search" fill={true}
             defaultValue={searchText} onChange={this._onSearch}


### PR DESCRIPTION
![screen shot 2016-05-05 at 3 06 56 pm](https://cloud.githubusercontent.com/assets/3210082/15090659/89911e7e-13ca-11e6-87d9-2c8e11fb69b1.png)

Easiest way to fix this issue was to wrap it in a `div`.

Another possible fix would be to remove `width: 100%` from `.search-fill` https://github.com/grommet/grommet/blob/master/src/scss/grommet-core/_objects.search.scss#L235