### PR TITLE
Rename 'result' prop to 'data'

### DIFF
--- a/src/js/components/Items.js
+++ b/src/js/components/Items.js
@@ -116,7 +116,7 @@ class Items extends Component {
           attributes={index.attributes}
           query={index.query}
           filter={index.filters}
-          result={index.result}
+          data={index.result}
           selection={selection}
           size={size}
           flush={false}


### PR DESCRIPTION
Fix console warning. 'result' will be removed from grommet-index Index component.

![screen shot 2016-05-12 at 7 02 13 pm](https://cloud.githubusercontent.com/assets/3210082/15240343/a09d830a-1884-11e6-9416-418dee4a138a.png)
