### PR TITLE
Fix object.assign error in IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [ "es2015", "react" ],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-object-assign"
   ]
 }

--- a/grommet-toolbox.config.js
+++ b/grommet-toolbox.config.js
@@ -26,6 +26,15 @@ export default {
         path.resolve(__dirname, 'src/scss'),
         path.resolve(__dirname, 'node_modules')
       ]
+    },
+    module: {
+      loaders: [
+        {
+          test: /\.jsx?$/,
+          loader: 'babel-loader',
+          include: /node_modules\/react-gravatar/
+        }
+      ]
     }
   },
   devServerPort: 8001,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "del": "^2.0.2",


### PR DESCRIPTION
The dist file `node_modules/react-gravatar/dist/index.js` uses `Object.assign`. 😕 

![screen shot 2016-05-15 at 1 44 22 am](https://cloud.githubusercontent.com/assets/3210082/15273901/3004efb0-1a42-11e6-992d-cdf83edac2ce.png)

Since it's in the `node_modules` folder, it gets excluded from the js loader; babel can't transform it. https://github.com/grommet/grommet-toolbox/blob/master/src/gulp-options-builder.js#L31

I'm creating a loader specifically for `react-gravatar` because it needs to run through babel in order for the `transform-object-assign` plugin to work.

This may not be the right solution, but it gets the job done..

Thoughts?

