### PR TITLE
include all dev dependencies: babel-core, babel-loader, babel-plugin-…

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,15 @@
     "ws": "^0.7.2"
   },
   "devDependencies": {
-    "babel-plugin-transform-object-rest-spread": "^6.3.13",
+    "babel-core": "^6.9.0",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
+    "babel-register": "^6.9.0",
+    "css-loader": "^0.23.1",
     "del": "^2.0.2",
     "grommet-toolbox": "^0.1.14",
     "gulp": "^3.9.0",
@@ -40,10 +45,13 @@
     "gulp-nodemon": "^2.0.3",
     "gulp-rsync": "0.0.5",
     "mkdirp": "^0.5.1",
+    "node-sass": "^3.7.0",
     "react-hot-loader": "^1.3.0",
     "redux-devtools": "^3.0.1",
     "redux-devtools-dock-monitor": "^1.0.1",
     "redux-devtools-log-monitor": "^1.0.1",
+    "sass-loader": "^3.2.0",
+    "style-loader": "^0.13.1",
     "yargs": "^3.30.0"
   },
   "scripts": {


### PR DESCRIPTION
Hopefully this would save other webpack and babel newbies some time. Ferret app looks great

include all dev dependencies: babel-core, babel-loader, babel-plugin-add-module-exports, babel-plugin-transform-object-rest-spread, babel-register, css-loader, node-sass, sass-loader, style-loader