### PR TITLE
Missing logo + react-gravatar module build error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": [ "es2015", "react" ],
   "plugins": [
-    "transform-object-rest-spread",
-    "transform-object-assign"
+    "transform-object-rest-spread"
   ]
 }

--- a/grommet-toolbox.config.js
+++ b/grommet-toolbox.config.js
@@ -26,15 +26,6 @@ export default {
         path.resolve(__dirname, 'src/scss'),
         path.resolve(__dirname, 'node_modules')
       ]
-    },
-    module: {
-      loaders: [
-        {
-          test: /\.jsx?$/,
-          loader: 'babel-loader',
-          include: /node_modules\/react-gravatar/
-        }
-      ]
     }
   },
   devServerPort: 8001,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "babel-core": "^6.9.0",
     "babel-loader": "^6.2.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",

--- a/src/js/components/Logo.js
+++ b/src/js/components/Logo.js
@@ -2,7 +2,7 @@
 
 import React, { Component, PropTypes } from 'react';
 
-const CLASS_ROOT = 'logo-icon';
+const CLASS_ROOT = 'grommetux-logo-icon';
 
 class FerretLogo extends Component {
 


### PR DESCRIPTION
* fixes build error:
```
ERROR in ./~/react-gravatar/dist/index.js
Module build failed: Error: Couldn't find preset "stage-0" relative to directory
```
* prefix logo class with grommetux- so that logo appears in Ferret app (issue https://github.com/grommet/grommet-ferret/issues/32)

<img width="568" alt="screen shot 2016-07-08 at 3 29 15 pm" src="https://cloud.githubusercontent.com/assets/10161095/16705764/28a96b9c-4530-11e6-9499-ad4c7d50142d.png">